### PR TITLE
Merge branch 'codex/implement-spell-chess-variant-aevw9t'

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -152,7 +152,7 @@ tests/                # Test scripts and data
 - [Chess Variants on Chess.com](https://www.chess.com/variants)
 
 ### Development Best Practices
-* Make sure to only stage and commit changes that are intended to be part of the task.
+* Make sure to only stage and commit changes that were changed as part of the task, do not simply add all changes.
 * Keep changes minimal and focused on the task at hand.
 * After applying changes make sure that all places related to the task have been identified.
 * Stay consistent with the existing code style and conventions.

--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -36,7 +36,7 @@ jobs:
       run:
         working-directory: src
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: [12.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup cache
         id: cache-system-libraries
         uses: actions/cache@v4
@@ -31,7 +31,7 @@ jobs:
           version: ${{env.EM_VERSION}}
           actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - name: Build ffishjs
@@ -53,7 +53,7 @@ jobs:
         node-version: [12.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup cache
         id: cache-system-libraries
         uses: actions/cache@v4
@@ -65,7 +65,7 @@ jobs:
           version: ${{env.EM_VERSION}}
           actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - name: Build ffish.js ES6/ES2015 module

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
             maximum-size: 16GB
             disk-root: "C:"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: make
         run: cd src && make clean && make -j build COMP=mingw ARCH=${{ matrix.arch }} EXE=fairy-stockfish_${{ matrix.arch }}.exe && strip fairy-stockfish_${{ matrix.arch }}.exe
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: make
         run: cd src && make clean && make -j build COMP=gcc ARCH=${{ matrix.arch }} EXE=fairy-stockfish_${{ matrix.arch }} && strip fairy-stockfish_${{ matrix.arch }}
@@ -72,7 +72,7 @@ jobs:
     runs-on: macos-13
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: make
         run: cd src && make clean && make -j build COMP=clang ARCH=${{ matrix.arch }} EXE=fairy-stockfish_${{ matrix.arch }} && strip fairy-stockfish_${{ matrix.arch }}
@@ -97,7 +97,7 @@ jobs:
     runs-on: macos-14
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: make
         run: cd src && make clean && make -j build COMP=clang ARCH=${{ matrix.arch }} EXE=fairy-stockfish_${{ matrix.arch }} && strip fairy-stockfish_${{ matrix.arch }}

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -39,7 +39,7 @@ jobs:
       run:
         working-directory: src
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,10 +17,10 @@ jobs:
         os: [ubuntu-24.04, windows-2022, macos-13]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.22.0
@@ -43,8 +43,8 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Ignore binaries in src/ that have no extension
+/src/*
+!/src/*.*
+!/src/*/
+
 # Files from build
 **/*.o
 **/*.s
@@ -29,6 +34,9 @@ __pycache__
 
 # test artifacts
 tests/*.exp
+src/*.log
+src/*.epd
+src/*.txt
 
 # IDEs
 .vscode

--- a/README.md
+++ b/README.md
@@ -11,7 +11,117 @@ For development, see [`src/emscripten/README.md`](src/emscripten/README.md).
 
 Current default branch is `nnue`.
 
+If you want to preview the functionality of Fairy-Stockfish before downloading, you can try it out on the [Fairy-Stockfish playground](https://fairyground.vercel.app/) in the browser.
+
+Optional NNUE evaluation parameter files to improve playing strength for many variants are in the [list of NNUE networks](https://fairy-stockfish.github.io/nnue/#current-best-nnue-networks).
+For the regional variants Xiangqi, Janggi, and Makruk [dedicated releases with built-in NNUE networks](https://github.com/fairy-stockfish/Fairy-Stockfish-NNUE) are available. See the [wiki](https://github.com/fairy-stockfish/Fairy-Stockfish/wiki/NNUE) for more details on NNUE.
+
 To release a new version:
 * Make sure CI passes (update reference bench if required)
 * Bump version number in `src/emscripten/public/package.json`
 * Create and push a tag with the name corresponding to the version number
+
+## Contributing
+
+If you like this project, please support its development via [patreon](https://www.patreon.com/ianfab), [paypal](https://paypal.me/FairyStockfish), or [github](https://github.com/sponsors/ianfab), or by [contributing to the code](https://github.com/fairy-stockfish/Fairy-Stockfish/wiki/Contributing) or documentation. An [introduction to the code base](https://github.com/fairy-stockfish/Fairy-Stockfish/wiki/Understanding-the-code) can be found in the wiki.
+
+## Supported games
+
+The games currently supported besides chess are listed below. Fairy-Stockfish can also play user-defined variants loaded via a variant configuration file, see the file [`src/variants.ini`](https://github.com/ianfab/Fairy-Stockfish/blob/master/src/variants.ini) and the [wiki](https://github.com/fairy-stockfish/Fairy-Stockfish/wiki/Variant-configuration).
+
+### Regional and historical games
+- [Xiangqi](https://en.wikipedia.org/wiki/Xiangqi), [Manchu](https://en.wikipedia.org/wiki/Manchu_chess), [Minixiangqi](http://mlwi.magix.net/bg/minixiangqi.htm), [Supply chess](https://en.wikipedia.org/wiki/Xiangqi#Variations)
+- [Shogi](https://en.wikipedia.org/wiki/Shogi), [Shogi variants](https://github.com/fairy-stockfish/Fairy-Stockfish#shogi-variants)
+- [Janggi](https://en.wikipedia.org/wiki/Janggi)
+- [Makruk](https://en.wikipedia.org/wiki/Makruk), [ASEAN](http://hgm.nubati.net/rules/ASEAN.html), Makpong, Ai-Wok
+- [Ouk Chatrang](https://en.wikipedia.org/wiki/Makruk#Cambodian_chess), [Kar Ouk](https://en.wikipedia.org/wiki/Makruk#Cambodian_chess)
+- [Sittuyin](https://en.wikipedia.org/wiki/Sittuyin)
+- [Shatar](https://en.wikipedia.org/wiki/Shatar), [Jeson Mor](https://en.wikipedia.org/wiki/Jeson_Mor)
+- [Shatranj](https://en.wikipedia.org/wiki/Shatranj), [Courier](https://en.wikipedia.org/wiki/Courier_chess)
+- [Raazuvaa](https://www.reddit.com/r/chess/comments/sj7y3n/raazuvaa_the_chess_of_the_maldives)
+
+### Chess variants
+- [Capablanca](https://en.wikipedia.org/wiki/Capablanca_Chess), [Janus](https://en.wikipedia.org/wiki/Janus_Chess), [Modern](https://en.wikipedia.org/wiki/Modern_Chess_(chess_variant)), [Chancellor](https://en.wikipedia.org/wiki/Chancellor_Chess), [Embassy](https://en.wikipedia.org/wiki/Embassy_Chess), [Gothic](https://www.chessvariants.com/large.dir/gothicchess.html), [Capablanca random chess](https://en.wikipedia.org/wiki/Capablanca_Random_Chess)
+- [Grand](https://en.wikipedia.org/wiki/Grand_Chess), [Shako](https://www.chessvariants.com/large.dir/shako.html), [Centaur](https://www.chessvariants.com/large.dir/contest/royalcourt.html), [Tencubed](https://www.chessvariants.com/contests/10/tencubedchess.html), [Opulent](https://www.chessvariants.com/rules/opulent-chess)
+- [Chess960](https://en.wikipedia.org/wiki/Chess960), [Placement/Pre-Chess](https://www.chessvariants.com/link/placement-chess)
+- [Crazyhouse](https://en.wikipedia.org/wiki/Crazyhouse), [Loop](https://en.wikipedia.org/wiki/Crazyhouse#Variations), [Chessgi](https://en.wikipedia.org/wiki/Crazyhouse#Variations), [Pocket Knight](http://www.chessvariants.com/other.dir/pocket.html), Capablanca-Crazyhouse
+- [Bughouse](https://en.wikipedia.org/wiki/Bughouse_chess), [Koedem](http://schachclub-oetigheim.de/wp-content/uploads/2016/04/Koedem-rules.pdf)
+- [Seirawan](https://en.wikipedia.org/wiki/Seirawan_chess), Seirawan-Crazyhouse, [Dragon Chess](https://www.edami.com/dragonchess/)
+- [Amazon](https://www.chessvariants.com/diffmove.dir/amazone.html), [Chigorin](https://www.chessvariants.com/diffsetup.dir/chigorin.html), [Almost chess](https://en.wikipedia.org/wiki/Almost_Chess)
+- [Hoppel-Poppel](http://www.chessvariants.com/diffmove.dir/hoppel-poppel.html), New Zealand
+- [Antichess](https://lichess.org/variant/antichess), [Giveaway](http://www.chessvariants.com/diffobjective.dir/giveaway.old.html), [Suicide](https://www.freechess.org/Help/HelpFiles/suicide_chess.html), [Losers](https://www.chessclub.com/help/Wild17), [Codrus](http://www.binnewirtz.com/Schlagschach1.htm)
+- [Extinction](https://en.wikipedia.org/wiki/Extinction_chess), [Kinglet](https://en.wikipedia.org/wiki/V._R._Parton#Kinglet_chess), Three Kings, [Coregal](https://www.chessvariants.com/winning.dir/coregal.html)
+- [King of the Hill](https://en.wikipedia.org/wiki/King_of_the_Hill_(chess)), [Racing Kings](https://en.wikipedia.org/wiki/V._R._Parton#Racing_Kings)
+- [Three-check](https://en.wikipedia.org/wiki/Three-check_chess), Five-check
+- [Los Alamos](https://en.wikipedia.org/wiki/Los_Alamos_chess), [Gardner's Minichess](https://en.wikipedia.org/wiki/Minichess#5%C3%975_chess)
+- [Atomic](https://en.wikipedia.org/wiki/Atomic_chess)
+- [Horde](https://en.wikipedia.org/wiki/Dunsany%27s_Chess#Horde_Chess), [Maharajah and the Sepoys](https://en.wikipedia.org/wiki/Maharajah_and_the_Sepoys)
+- [Knightmate](https://www.chessvariants.com/diffobjective.dir/knightmate.html), [Nightrider](https://en.wikipedia.org/wiki/Nightrider_(chess)), [Grasshopper](https://en.wikipedia.org/wiki/Grasshopper_chess)
+- [Duck chess](https://duckchess.com/), [Omicron](http://www.eglebbk.dds.nl/program/chess-omicron.html), [Gustav III](https://www.chessvariants.com/play/gustav-iiis-chess)
+- [Berolina Chess](https://en.wikipedia.org/wiki/Berolina_pawn#Berolina_chess), [Pawn-Sideways](https://arxiv.org/abs/2009.04374), [Pawn-Back](https://arxiv.org/abs/2009.04374), [Torpedo](https://arxiv.org/abs/2009.04374), [Legan Chess](https://en.wikipedia.org/wiki/Legan_chess)
+- [Spartan Chess](https://www.chessvariants.com/rules/spartan-chess)
+- [Wolf Chess](https://en.wikipedia.org/wiki/Wolf_chess)
+- [Troitzky Chess](https://www.chessvariants.com/play/troitzky-chess)
+
+### Shogi variants
+- [Minishogi](https://en.wikipedia.org/wiki/Minishogi), [EuroShogi](https://en.wikipedia.org/wiki/EuroShogi), [Judkins shogi](https://en.wikipedia.org/wiki/Judkins_shogi)
+- [Kyoto shogi](https://en.wikipedia.org/wiki/Kyoto_shogi), [Microshogi](https://en.wikipedia.org/wiki/Micro_shogi)
+- [Dobutsu shogi](https://en.wikipedia.org/wiki/Dōbutsu_shōgi), [Goro goro shogi](https://en.wikipedia.org/wiki/D%C5%8Dbutsu_sh%C5%8Dgi#Variation)
+- [Tori shogi](https://en.wikipedia.org/wiki/Tori_shogi)
+- [Yari shogi](https://en.wikipedia.org/wiki/Yari_shogi)
+- [Okisaki shogi](https://en.wikipedia.org/wiki/Okisaki_shogi)
+- [Sho shogi](https://en.wikipedia.org/wiki/Sho_shogi)
+
+### Related games
+- [Amazons](https://en.wikipedia.org/wiki/Game_of_the_Amazons)
+- [Ataxx](https://en.wikipedia.org/wiki/Ataxx)
+- [Breakthrough](https://en.wikipedia.org/wiki/Breakthrough_(board_game))
+- [Clobber](https://en.wikipedia.org/wiki/Clobber)
+- [Cfour](https://en.wikipedia.org/wiki/Connect_Four), [Tic-tac-toe](https://en.wikipedia.org/wiki/Tic-tac-toe)
+- [Five Field Kono](https://en.wikipedia.org/wiki/Five_Field_Kono)
+- [Flipersi](https://en.wikipedia.org/wiki/Reversi), [Flipello](https://en.wikipedia.org/wiki/Reversi#Othello)
+- [Fox and Hounds](https://boardgamegeek.com/boardgame/148180/fox-and-hounds)
+- [Isolation](https://boardgamegeek.com/boardgame/1875/isolation)
+- [Joust](https://www.chessvariants.com/programs.dir/joust.html)
+- [Snailtrail](https://boardgamegeek.com/boardgame/37135/snailtrail)
+
+
+## Help
+
+See the [Fairy-Stockfish Wiki](https://github.com/fairy-stockfish/Fairy-Stockfish/wiki) for more info, or if the required information is not available, open an [issue](https://github.com/fairy-stockfish/Fairy-Stockfish/issues) or join our [discord server](https://discord.gg/FYUGgmCFB4).
+
+## Bindings
+
+Besides the C++ engine, this project also includes bindings for other programming languages in order to be able to use it as a library for chess variants. They support move, SAN, and FEN generation, as well as checking of game end conditions for all variants supported by Fairy-Stockfish. Since the bindings are using the C++ code, they are very performant compared to libraries directly written in the respective target language.
+
+### Python
+
+The python binding [pyffish](https://pypi.org/project/pyffish/) contributed by [@gbtami](https://github.com/gbtami) is implemented in [pyffish.cpp](https://github.com/fairy-stockfish/Fairy-Stockfish/blob/master/src/pyffish.cpp). It is e.g. used in the backend for the [pychess server](https://github.com/gbtami/pychess-variants).
+
+### Javascript
+
+The javascript binding [ffish.js](https://www.npmjs.com/package/ffish) contributed by [@QueensGambit](https://github.com/QueensGambit) is implemented in [ffishjs.cpp](https://github.com/fairy-stockfish/Fairy-Stockfish/blob/master/src/ffishjs.cpp). The compilation/binding to javascript is done using emscripten, see the [readme](https://github.com/fairy-stockfish/Fairy-Stockfish/tree/master/tests/js).
+
+## Ports
+
+### WebAssembly
+
+For in-browser use a [port of Fairy-Stockfish to WebAssembly](https://github.com/fairy-stockfish/fairy-stockfish.wasm) is available at [npm](https://www.npmjs.com/package/fairy-stockfish-nnue.wasm). It is e.g. used for local analysis on [pychess.org](https://www.pychess.org/analysis/chess). Also see the [Fairy-Stockfish WASM demo](https://github.com/ianfab/fairy-stockfish-nnue-wasm-demo) available at https://fairy-stockfish-nnue-wasm.vercel.app/.
+
+## Terms of use
+
+Fairy-Stockfish is free, and distributed under the **GNU General Public License version 3**
+(GPL v3). Essentially, this means you are free to do almost exactly
+what you want with the program, including distributing it among your
+friends, making it available for download from your website, selling
+it (either by itself or as part of some bigger software package), or
+using it as the starting point for a software project of your own.
+
+The only real limitation is that whenever you distribute Fairy-Stockfish in
+some way, you MUST always include the full source code, or a pointer
+to where the source code can be found, to generate the exact binary
+you are distributing. If you make any changes to the source code,
+these changes must also be made available under the GPL.
+
+For full details, read the copy of the GPL v3 found in the file named
+[*Copying.txt*](https://github.com/fairy-stockfish/Fairy-Stockfish/blob/master/Copying.txt).

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ with io.open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read().strip()
 
 sources = glob("src/*.cpp") + glob("src/syzygy/*.cpp") + glob("src/nnue/*.cpp") + glob("src/nnue/features/*.cpp")
+headers = glob("src/*.h") + glob("src/syzygy/*.h") + glob("src/nnue/*.h") + glob("src/nnue/features/*.h")
 ffish_source_file = os.path.normcase("src/ffishjs.cpp")
 try:
     sources.remove(ffish_source_file)
@@ -37,6 +38,7 @@ except ValueError:
 pyffish_module = Extension(
     "pyffish",
     sources=sources,
+    depends=headers,
     extra_compile_args=args)
 
 setup(name="pyffish", version="0.0.88",

--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -372,31 +372,53 @@ inline bool has_insufficient_material(Color c, const Position& pos) {
         || (pos.flag_region(c) && pos.count(c, pos.flag_piece(c))))
         return false;
 
-    // Restricted pieces
-    Bitboard restricted = pos.pieces(~c, KING);
-    // Atomic kings can not help checkmating
-    if (pos.extinction_pseudo_royal() && pos.blast_on_capture() && (pos.extinction_piece_types() & COMMONER))
-        restricted |= pos.pieces(c, COMMONER);
+    // Precalculate if any promotion pawn types have pieces
+    bool hasPromotingPawn = false;
+    for (PieceSet pawnTypes = pos.promotion_pawn_types(c); pawnTypes; )
+    {
+        PieceType pawnType = pop_lsb(pawnTypes);
+        if (pos.count(c, pawnType) > 0)
+        {
+            hasPromotingPawn = true;
+            break;
+        }
+    }
+
+    // Determine checkmating potential of present pieces
+    constexpr PieceSet MAJOR_PIECES = piece_set(ROOK) | QUEEN | ARCHBISHOP | CHANCELLOR
+                                     | SILVER | GOLD | COMMONER | CENTAUR | AMAZON | BERS;
+    constexpr PieceSet COLORBOUND_PIECES = piece_set(BISHOP) | FERS | FERS_ALFIL | ALFIL | ELEPHANT;
+    Bitboard restricted = pos.pieces(KING);
+    Bitboard colorbound = 0;
     for (PieceSet ps = pos.piece_types(); ps;)
     {
         PieceType pt = pop_lsb(ps);
-        if (pt == KING || !(pos.board_bb(c, pt) & pos.board_bb(~c, KING)))
+
+        // Constrained pieces
+        if (pt == KING || !(pos.board_bb(c, pt) & pos.board_bb(~c, KING)) || (pos.extinction_pseudo_royal() && pos.blast_on_capture() && (pos.extinction_piece_types() & pt)))
             restricted |= pos.pieces(c, pt);
-        else if (is_custom(pt) && pos.count(c, pt) > 0)
-            // to be conservative, assume any custom piece has mating potential
-            return false;
+
+        // If piece is a major piece or a custom piece we consider it sufficient for mate.
+        // To avoid false positives, we assume any custom piece has mating potential.
+        else if ((MAJOR_PIECES & pt) || is_custom(pt))
+        {
+            // Check if piece is already on the board
+            if (pos.count(c, pt) > 0)
+                return false;
+
+            // Check if any pawn can promote to this piece type
+            if (hasPromotingPawn && (pos.promotion_piece_types(c) & pt))
+                return false;
+        }
+
+        // Collect color-bound pieces
+        else if (COLORBOUND_PIECES & pt)
+            colorbound |= pos.pieces(pt);
     }
 
-    // Mating pieces
-    for (PieceType pt : { ROOK, QUEEN, ARCHBISHOP, CHANCELLOR, SILVER, GOLD, COMMONER, CENTAUR, AMAZON, BERS })
-        if ((pos.pieces(c, pt) & ~restricted) || (pos.count(c, pos.main_promotion_pawn_type(c)) && (pos.promotion_piece_types(c) & pt)))
-            return false;
+    Bitboard unbound = pos.pieces() ^ restricted ^ colorbound;
 
     // Color-bound pieces
-    Bitboard colorbound = 0, unbound;
-    for (PieceType pt : { BISHOP, FERS, FERS_ALFIL, ALFIL, ELEPHANT })
-        colorbound |= pos.pieces(pt) & ~restricted;
-    unbound = pos.pieces() ^ restricted ^ colorbound;
     if ((colorbound & pos.pieces(c)) && (((DarkSquares & colorbound) && (~DarkSquares & colorbound)) || unbound || pos.stalemate_value() != VALUE_DRAW || pos.check_counting() || pos.makpong()))
         return false;
 
@@ -962,7 +984,7 @@ inline std::string get_valid_special_chars(const Variant* v) {
         validSpecialCharactersFirstField += '+';
     if (v->promotionPieceTypes[WHITE] || v->promotionPieceTypes[BLACK])
         validSpecialCharactersFirstField += '~';
-    if (!v->freeDrops && (v->pieceDrops || v->seirawanGating))
+    if (!v->freeDrops && (v->pieceDrops || v->seirawanGating || v->potions))
         validSpecialCharactersFirstField += "[-]";
     return validSpecialCharactersFirstField;
 }
@@ -1010,7 +1032,7 @@ inline FenValidation validate_fen(const std::string& fen, const Variant* v, bool
 
     // check for pocket
     std::string pocket = "";
-    if (v->pieceDrops || v->seirawanGating)
+    if (v->pieceDrops || v->seirawanGating || v->potions)
     {
         if (check_pocket_info(fenParts[0], nbRanks, v, pocket) == NOK)
             return FEN_INVALID_POCKET_INFO;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -56,6 +56,44 @@ namespace {
 } // namespace
 
 
+bool MovePicker::is_useless_potion(Move m) const {
+
+  if (!pos.potions_enabled() || !is_gating(m))
+      return false;
+
+  PieceType gatingPiece = gating_type(m);
+
+  for (int idx = 0; idx < Variant::POTION_TYPE_NB; ++idx)
+  {
+      auto potion = static_cast<Variant::PotionType>(idx);
+      if (pos.potion_piece(potion) != gatingPiece)
+          continue;
+
+      if (potion == Variant::POTION_FREEZE)
+      {
+          Bitboard zone = pos.freeze_zone_from_square(gating_square(m));
+          Bitboard enemies = pos.pieces(~pos.side_to_move());
+          return !(zone & enemies);
+      }
+
+      if (potion == Variant::POTION_JUMP)
+      {
+          Square gate = gating_square(m);
+          if (pos.piece_on(gate) == NO_PIECE)
+              return true;
+
+          Bitboard path = between_bb(from_sq(m), to_sq(m), type_of(pos.moved_piece(m)));
+          path &= ~square_bb(to_sq(m));
+          return !(path & square_bb(gate));
+      }
+
+      break;
+  }
+
+  return false;
+}
+
+
 /// Constructors of the MovePicker class. As arguments we pass information
 /// to help it to return the (presumably) good moves first, to decide which
 /// moves to return (in the quiescence search, for instance, we only want to
@@ -144,7 +182,9 @@ Move MovePicker::select(Pred filter) {
       if (T == Best)
           std::swap(*cur, *std::max_element(cur, endMoves));
 
-      if (*cur != ttMove && filter())
+      Move move = *cur;
+
+      if (move != ttMove && !is_useless_potion(move) && filter())
           return *cur++;
 
       cur++;
@@ -165,8 +205,13 @@ top:
   case QSEARCH_TT:
   case PROBCUT_TT:
       ++stage;
-      assert(pos.legal(ttMove) == MoveList<LEGAL>(pos).contains(ttMove) || pos.virtual_drop(ttMove));
-      return ttMove;
+      if (ttMove && !is_useless_potion(ttMove))
+      {
+          assert(pos.legal(ttMove) == MoveList<LEGAL>(pos).contains(ttMove) || pos.virtual_drop(ttMove));
+          return ttMove;
+      }
+      ttMove = MOVE_NONE;
+      goto top;
 
   case CAPTURE_INIT:
   case PROBCUT_INIT:

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -145,6 +145,7 @@ public:
 private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
+  bool is_useless_potion(Move m) const;
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -419,6 +419,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("blastOnCapture", v->blastOnCapture);
     parse_attribute("blastImmuneTypes", v->blastImmuneTypes, v->pieceToChar);
     parse_attribute("mutuallyImmuneTypes", v->mutuallyImmuneTypes, v->pieceToChar);
+    parse_attribute("ironPieceTypes", v->ironPieceTypes, v->pieceToChar);
     parse_attribute("petrifyOnCaptureTypes", v->petrifyOnCaptureTypes, v->pieceToChar);
     parse_attribute("petrifyBlastPieces", v->petrifyBlastPieces);
     parse_attribute("doubleStep", v->doubleStep);
@@ -426,7 +427,10 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("doubleStepRegionBlack", v->doubleStepRegion[BLACK]);
     parse_attribute("tripleStepRegionWhite", v->tripleStepRegion[WHITE]);
     parse_attribute("tripleStepRegionBlack", v->tripleStepRegion[BLACK]);
-    parse_attribute("enPassantRegion", v->enPassantRegion);
+    parse_attribute("enPassantRegion", v->enPassantRegion[WHITE]);
+    parse_attribute("enPassantRegion", v->enPassantRegion[BLACK]);
+    parse_attribute("enPassantRegionWhite", v->enPassantRegion[WHITE]);
+    parse_attribute("enPassantRegionBlack", v->enPassantRegion[BLACK]);
     parse_attribute("enPassantTypes", v->enPassantTypes[WHITE], v->pieceToChar);
     parse_attribute("enPassantTypes", v->enPassantTypes[BLACK], v->pieceToChar);
     parse_attribute("enPassantTypesWhite", v->enPassantTypes[WHITE], v->pieceToChar);
@@ -451,6 +455,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("checking", v->checking);
     parse_attribute("dropChecks", v->dropChecks);
     parse_attribute("mustCapture", v->mustCapture);
+    parse_attribute("selfCapture", v->selfCapture);
     parse_attribute("mustDrop", v->mustDrop);
     parse_attribute("mustDropType", v->mustDropType, v->pieceToChar);
     parse_attribute("pieceDrops", v->pieceDrops);
@@ -467,6 +472,12 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("dropPromoted", v->dropPromoted);
     parse_attribute("dropNoDoubled", v->dropNoDoubled, v->pieceToChar);
     parse_attribute("dropNoDoubledCount", v->dropNoDoubledCount);
+    parse_attribute("potions", v->potions);
+    parse_attribute("freezePotion", v->potionPiece[Variant::POTION_FREEZE], v->pieceToChar);
+    parse_attribute("jumpPotion", v->potionPiece[Variant::POTION_JUMP], v->pieceToChar);
+    parse_attribute("freezeCooldown", v->potionCooldown[Variant::POTION_FREEZE]);
+    parse_attribute("jumpCooldown", v->potionCooldown[Variant::POTION_JUMP]);
+    parse_attribute("potionDropOnOccupied", v->potionDropOnOccupied);
     parse_attribute("immobilityIllegal", v->immobilityIllegal);
     parse_attribute("gating", v->gating);
     parse_attribute("wallingRule", v->wallingRule);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -36,6 +36,36 @@ using std::string;
 
 namespace Stockfish {
 
+namespace {
+
+  inline Variant::PotionType potion_type_from_piece(const Variant* var, PieceType pt) {
+    if (!var || !var->potions)
+        return static_cast<Variant::PotionType>(Variant::POTION_TYPE_NB);
+    if (pt == var->potionPiece[Variant::POTION_FREEZE])
+        return Variant::POTION_FREEZE;
+    if (pt == var->potionPiece[Variant::POTION_JUMP])
+        return Variant::POTION_JUMP;
+    return static_cast<Variant::PotionType>(Variant::POTION_TYPE_NB);
+  }
+
+  struct SpellContextScope {
+    Position& pos;
+    bool active;
+
+    SpellContextScope(const Position& position, Bitboard freezeExtra, Bitboard jumpRemoved)
+        : pos(const_cast<Position&>(position)), active((freezeExtra | jumpRemoved) != Bitboard(0)) {
+        if (active)
+            pos.set_spell_context(freezeExtra, jumpRemoved);
+    }
+
+    ~SpellContextScope() {
+        if (active)
+            pos.clear_spell_context();
+    }
+  };
+
+} // namespace
+
 namespace Zobrist {
 
   Key psq[PIECE_NB][SQUARE_NB];
@@ -44,9 +74,32 @@ namespace Zobrist {
   Key side, noPawns;
   Key inHand[PIECE_NB][SQUARE_NB];
   Key checks[COLOR_NB][CHECKS_NB];
+  Key potionZone[COLOR_NB][Variant::POTION_TYPE_NB][SQUARE_NB];
+  Key potionCooldown[COLOR_NB][Variant::POTION_TYPE_NB][POTION_COOLDOWN_BITS];
   Key wall[SQUARE_NB];
   Key endgame[EG_EVAL_NB];
 }
+
+
+namespace {
+
+  inline void xor_potion_zone(Key& key, Color c, Variant::PotionType potion, Bitboard zone) {
+      while (zone)
+          key ^= Zobrist::potionZone[c][potion][pop_lsb(zone)];
+  }
+
+  inline void xor_potion_cooldown(Key& key, Color c, Variant::PotionType potion, int cooldown) {
+      assert(cooldown >= 0);
+      unsigned value = static_cast<unsigned>(cooldown);
+      assert(value < (1u << POTION_COOLDOWN_BITS));
+      if (!value)
+          return;
+      for (int bit = 0; bit < POTION_COOLDOWN_BITS; ++bit)
+          if (value & (1u << bit))
+              key ^= Zobrist::potionCooldown[c][potion][bit];
+  }
+
+} // namespace
 
 
 /// operator<<(Position) returns an ASCII representation of the position
@@ -175,6 +228,16 @@ void Position::init() {
       for (PieceType pt = PAWN; pt <= KING; ++pt)
           for (int n = 0; n < SQUARE_NB; ++n)
               Zobrist::inHand[make_piece(c, pt)][n] = rng.rand<Key>();
+
+  for (Color c : {WHITE, BLACK})
+      for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+      {
+          for (Square s = SQ_A1; s <= SQ_MAX; ++s)
+              Zobrist::potionZone[c][pt][s] = rng.rand<Key>();
+
+          for (int bit = 0; bit < POTION_COOLDOWN_BITS; ++bit)
+              Zobrist::potionCooldown[c][pt][bit] = rng.rand<Key>();
+      }
 
   for (Square s = SQ_A1; s <= SQ_MAX; ++s)
       Zobrist::wall[s] = rng.rand<Key>();
@@ -447,7 +510,7 @@ Position& Position::set(const Variant* v, const string& fenStr, bool isChess960,
               // a) side to move have a pawn threatening epSquare
               // b) there is an enemy pawn one or two (for triple steps) squares in front of epSquare
               // c) there is no (non-wall) piece on epSquare or behind epSquare
-              if (   (var->enPassantRegion & epSquare)
+              if (   (var->enPassantRegion[sideToMove] & epSquare)
                   && (   !var->fastAttacks
                       || (var->enPassantTypes[sideToMove] & ~piece_set(PAWN))
                       || (   pawn_attacks_bb(~sideToMove, epSquare) & pieces(sideToMove, PAWN)
@@ -659,6 +722,18 @@ void Position::set_state(StateInfo* si) const {
               si->key ^= Zobrist::inHand[pc][pieceCountInHand[c][pt]];
       }
 
+  if (potions_enabled())
+      for (Color c : {WHITE, BLACK})
+          for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+          {
+              Variant::PotionType potion = static_cast<Variant::PotionType>(pt);
+              if (potion_piece(potion) == NO_PIECE_TYPE)
+                  continue;
+
+              xor_potion_zone(si->key, c, potion, si->potionZones[c][pt]);
+              xor_potion_cooldown(si->key, c, potion, si->potionCooldown[c][pt]);
+          }
+
   if (check_counting())
       for (Color c : {WHITE, BLACK})
           si->key ^= Zobrist::checks[c][si->checksRemaining[c]];
@@ -746,7 +821,7 @@ string Position::fen(bool sfen, bool showPromoted, int countStarted, std::string
   }
 
   // pieces in hand
-  if (!free_drops() && (piece_drops() || seirawan_gating()))
+  if (!free_drops() && (piece_drops() || seirawan_gating() || potions_enabled()))
   {
       ss << '[';
       if (holdings != "-")
@@ -1049,6 +1124,34 @@ bool Position::legal(Move m) const {
   Square from = from_sq(m);
   Square to = to_sq(m);
 
+  Bitboard freezeExtra = 0;
+  Bitboard jumpRemoved = 0;
+  Variant::PotionType gatingPotion = Variant::POTION_TYPE_NB;
+  if (is_gating(m))
+  {
+      gatingPotion = potion_type_from_piece(var, gating_type(m));
+      if (gatingPotion != Variant::POTION_TYPE_NB)
+      {
+          if (!can_cast_potion(us, gatingPotion))
+              return false;
+          if (gatingPotion == Variant::POTION_FREEZE)
+              freezeExtra = freeze_zone_from_square(gating_square(m));
+          else if (gatingPotion == Variant::POTION_JUMP)
+          {
+              jumpRemoved = square_bb(gating_square(m));
+              if (!piece_on(gating_square(m)))
+                  return false;
+          }
+      }
+  }
+
+  SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
+
+  if (type_of(m) != DROP && (freeze_squares() & from))
+      return false;
+  if (jumpRemoved && (square_bb(to) & jumpRemoved))
+      return false;
+
   assert(color_of(moved_piece(m)) == us);
   assert(!count<KING>(us) || piece_on(square<KING>(us)) == make_piece(us, KING));
   assert(board_bb() & to);
@@ -1127,10 +1230,12 @@ bool Position::legal(Move m) const {
           // Chess960 as they would be in standard chess.
           kto = make_square(to > from ? castling_kingside_file() : castling_queenside_file(), castling_rank(us));
           Direction step = kto > from ? EAST : WEST;
-          Square rto = kto - step;
+          Square rto = kto - (to > from ? EAST : WEST);
           // Pseudo-royal king
           if (st->pseudoRoyals & from)
-              for (Square s = from; s != kto; s += step)
+              // Loop over squares between the king and its final position
+              // Ensure to include the initial square if from == kto
+              for (Square s = from; from != kto ? s != kto : s == from; s += step)
                   if (  !(blast_on_capture() && (attacks_bb<KING>(s) & st->pseudoRoyals & pieces(~sideToMove)))
                       && attackers_to(s, occupied, ~us))
                       return false;
@@ -1146,6 +1251,9 @@ bool Position::legal(Move m) const {
       if (capture(m) && (var->petrifyOnCaptureTypes & type_of(moved_piece(m))) && (st->pseudoRoyals & from))
           return false;
       Bitboard pseudoRoyals = st->pseudoRoyals & pieces(sideToMove);
+      // Add dropped pseudo-royal
+      if (type_of(m) == DROP && (extinction_piece_types() & type_of(moved_piece(m))))
+          pseudoRoyals |= square_bb(to);
       Bitboard pseudoRoyalsTheirs = st->pseudoRoyals & pieces(~sideToMove);
       if (is_ok(from) && (pseudoRoyals & from))
           pseudoRoyals ^= square_bb(from) ^ kto;
@@ -1204,6 +1312,14 @@ bool Position::legal(Move m) const {
       (type_of(moved_piece(m)) == type_of(piece_on(to)))
   )
   return false;
+
+  // Iron pieces: any attempt to capture them is illegal (but they can capture normally)
+  if (capture(m)) {
+      Square csq = (type_of(m) == EN_PASSANT) ? capture_square(to) : to;
+      Piece  cpc = piece_on(csq);
+      if (cpc != NO_PIECE && (iron_piece_types() & type_of(cpc)))
+          return false;
+  }
 
   // En passant captures are a tricky special case. Because they are rather
   // uncommon, we do it simply by testing whether the king is attacked after
@@ -1312,6 +1428,33 @@ bool Position::pseudo_legal(const Move m) const {
 
   // Use a slower but simpler function for uncommon cases
   // yet we skip the legality check of MoveList<LEGAL>().
+  Bitboard freezeExtra = 0;
+  Bitboard jumpRemoved = 0;
+  if (is_gating(m))
+  {
+      Variant::PotionType potion = potion_type_from_piece(var, gating_type(m));
+      if (potion != Variant::POTION_TYPE_NB)
+      {
+          if (!can_cast_potion(us, potion))
+              return false;
+          if (potion == Variant::POTION_FREEZE)
+              freezeExtra = freeze_zone_from_square(gating_square(m));
+          else if (potion == Variant::POTION_JUMP)
+          {
+              jumpRemoved = square_bb(gating_square(m));
+              if (!piece_on(gating_square(m)))
+                  return false;
+          }
+      }
+  }
+
+  SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
+
+  if (type_of(m) != DROP && (freeze_squares() & from))
+      return false;
+  if (jumpRemoved && (square_bb(to) & jumpRemoved))
+      return false;
+
   if (type_of(m) != NORMAL || is_gating(m))
       return checkers() ? MoveList<    EVASIONS>(*this).contains(m)
                         : MoveList<NON_EVASIONS>(*this).contains(m);
@@ -1357,9 +1500,16 @@ bool Position::pseudo_legal(const Move m) const {
   if (pc == NO_PIECE || color_of(pc) != us)
       return false;
 
-  // The destination square cannot be occupied by a friendly piece
+  // The destination square cannot be occupied by a friendly piece unless self capture is allowed
   if (pieces(us) & to)
-      return false;
+  {
+      if (!(self_capture() && capture(m)))
+          return false;
+
+      // Friendly kings are never capturable, even when self-capture is enabled
+      if (type_of(piece_on(to)) == KING)
+          return false;
+  }
 
   // Handle the special case of a pawn move
   if (type_of(pc) == PAWN)
@@ -1369,7 +1519,8 @@ bool Position::pseudo_legal(const Move m) const {
       if (mandatory_pawn_promotion() && (promotion_zone(us) & to) && !sittuyin_promotion())
           return false;
 
-      if (   !(pawn_attacks_bb(us, from) & pieces(~us) & to)     // Not a capture
+      if (   !(pawn_attacks_bb(us, from)
+              & (self_capture() ? pieces() : pieces(~us)) & to)     // Not a capture
           && !((from + pawn_push(us) == to) && !(pieces() & to)) // Not a single push
           && !(   (from + 2 * pawn_push(us) == to)               // Not a double push
                && (double_step_region(us) & from)
@@ -1422,6 +1573,33 @@ bool Position::gives_check(Move m) const {
 
   Square from = from_sq(m);
   Square to = to_sq(m);
+
+  Bitboard freezeExtra = 0;
+  Bitboard jumpRemoved = 0;
+  if (is_gating(m))
+  {
+      Variant::PotionType potion = potion_type_from_piece(var, gating_type(m));
+      if (potion != Variant::POTION_TYPE_NB)
+      {
+          if (!can_cast_potion(sideToMove, potion))
+              return false;
+          if (potion == Variant::POTION_FREEZE)
+              freezeExtra = freeze_zone_from_square(gating_square(m));
+          else if (potion == Variant::POTION_JUMP)
+          {
+              jumpRemoved = square_bb(gating_square(m));
+              if (!piece_on(gating_square(m)))
+                  return false;
+          }
+      }
+  }
+
+  SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
+
+  if (type_of(m) != DROP && (freeze_squares() & from))
+      return false;
+  if (jumpRemoved && (square_bb(to) & jumpRemoved))
+      return false;
 
   // No check possible without king
   if (!count<KING>(~sideToMove))
@@ -1578,8 +1756,26 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   st->unpromotedCapturedPiece = captured ? unpromoted_piece_on(to) : NO_PIECE;
   st->pass = is_pass(m);
 
+  Variant::PotionType gatingPotion = Variant::POTION_TYPE_NB;
+  Bitboard freezeExtra = 0;
+  Bitboard jumpRemoved = 0;
+  if (is_gating(m))
+  {
+      gatingPotion = potion_type_from_piece(var, gating_type(m));
+      if (gatingPotion == Variant::POTION_FREEZE)
+          freezeExtra = freeze_zone_from_square(gating_square(m));
+      else if (gatingPotion == Variant::POTION_JUMP)
+          jumpRemoved = square_bb(gating_square(m));
+  }
+
+  SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
+
   assert(color_of(pc) == us);
-  assert(captured == NO_PIECE || color_of(captured) == (type_of(m) != CASTLING ? them : us));
+  assert(captured == NO_PIECE
+         || (type_of(m) == CASTLING
+             ? color_of(captured) == us
+             : (color_of(captured) == them
+                || (self_capture() && color_of(captured) == us))));
   assert(type_of(captured) != KING);
 
   if (check_counting() && givesCheck)
@@ -1607,7 +1803,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           st->captureSquare = capsq;
 
           assert(st->epSquares & to);
-          assert(var->enPassantRegion & to);
+          assert(var->enPassantRegion[us] & to);
           assert(piece_on(to) == NO_PIECE);
       }
 
@@ -1616,7 +1812,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       if (type_of(captured) == PAWN)
           st->pawnKey ^= Zobrist::psq[captured][capsq];
       else
-          st->nonPawnMaterial[them] -= PieceValue[MG][captured];
+          st->nonPawnMaterial[color_of(captured)] -= PieceValue[MG][captured];
 
       if (Eval::useNNUE)
       {
@@ -1635,10 +1831,10 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           board[capsq] = NO_PIECE;
       if (captures_to_hand())
       {
-          Piece pieceToHand = !capturedPromoted || drop_loop() ? ~captured
-                             : unpromotedCaptured ? ~unpromotedCaptured
-                                                  : make_piece(~color_of(captured), main_promotion_pawn_type(color_of(captured)));
-          add_to_hand(pieceToHand);
+           Piece pieceToHand = !capturedPromoted || drop_loop() ? make_piece(sideToMove, type_of(captured))
+		  				 : unpromotedCaptured ? make_piece(sideToMove, type_of(unpromotedCaptured))
+						                     : make_piece(sideToMove, main_promotion_pawn_type(color_of(captured)));
+		  add_to_hand(pieceToHand);
           k ^=  Zobrist::inHand[pieceToHand][pieceCountInHand[color_of(pieceToHand)][type_of(pieceToHand)] - 1]
               ^ Zobrist::inHand[pieceToHand][pieceCountInHand[color_of(pieceToHand)][type_of(pieceToHand)]];
 
@@ -1648,6 +1844,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
               dp.handCount[1] = pieceCountInHand[color_of(pieceToHand)][type_of(pieceToHand)];
           }
       }
+ 	  
       else if (Eval::useNNUE)
           dp.handPiece[1] = NO_PIECE;
 
@@ -1844,7 +2041,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           && (   std::abs(int(to) - int(from)) == 2 * NORTH
               || std::abs(int(to) - int(from)) == 3 * NORTH))
       {
-          if (   (var->enPassantRegion & (to - pawn_push(us)))
+          if (   (var->enPassantRegion[them] & (to - pawn_push(us)))
               && ((pawn_attacks_bb(us, to - pawn_push(us)) & pieces(them, PAWN)) || var->enPassantTypes[them] & ~piece_set(PAWN))
               && !(walling() && gating_square(m) == to - pawn_push(us)))
           {
@@ -1852,7 +2049,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
               k ^= Zobrist::enpassant[file_of(to)];
           }
           if (   std::abs(int(to) - int(from)) == 3 * NORTH
-              && (var->enPassantRegion & (to - 2 * pawn_push(us)))
+              && (var->enPassantRegion[them] & (to - 2 * pawn_push(us)))
               && ((pawn_attacks_bb(us, to - 2 * pawn_push(us)) & pieces(them, PAWN)) || var->enPassantTypes[them] & ~piece_set(PAWN))
               && !(walling() && gating_square(m) == to - 2 * pawn_push(us)))
           {
@@ -1924,7 +2121,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
            && ((PseudoMoves[1][us][type_of(pc)][from] & ~PseudoMoves[0][us][type_of(pc)][from]) & to))
   {
       assert(type_of(pc) != PAWN);
-      st->epSquares = between_bb(from, to) & var->enPassantRegion;
+      st->epSquares = between_bb(from, to) & var->enPassantRegion[them];
       for (Bitboard b = st->epSquares; b; )
           k ^= Zobrist::enpassant[file_of(pop_lsb(b))];
   }
@@ -1938,24 +2135,45 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       Square gate = gating_square(m);
       Piece gating_piece = make_piece(us, gating_type(m));
 
-      if (Eval::useNNUE)
+      if (gatingPotion != Variant::POTION_TYPE_NB)
       {
-          // Add gating piece
-          dp.piece[dp.dirty_num] = gating_piece;
-          dp.handPiece[dp.dirty_num] = gating_piece;
-          dp.handCount[dp.dirty_num] = pieceCountInHand[us][gating_type(m)];
-          dp.from[dp.dirty_num] = SQ_NONE;
-          dp.to[dp.dirty_num] = gate;
-          dp.dirty_num++;
+          int oldCount = pieceCountInHand[us][gating_type(m)];
+          remove_from_hand(gating_piece);
+          k ^= Zobrist::inHand[gating_piece][oldCount];
+          k ^= Zobrist::inHand[gating_piece][oldCount - 1];
+
+          if (Eval::useNNUE)
+          {
+              dp.handPiece[dp.dirty_num] = gating_piece;
+              dp.handCount[dp.dirty_num] = pieceCountInHand[us][gating_type(m)];
+              dp.piece[dp.dirty_num] = gating_piece;
+              dp.from[dp.dirty_num] = SQ_NONE;
+              dp.to[dp.dirty_num] = SQ_NONE;
+              dp.dirty_num++;
+          }
+
       }
+      else
+      {
+          if (Eval::useNNUE)
+          {
+              // Add gating piece
+              dp.piece[dp.dirty_num] = gating_piece;
+              dp.handPiece[dp.dirty_num] = gating_piece;
+              dp.handCount[dp.dirty_num] = pieceCountInHand[us][gating_type(m)];
+              dp.from[dp.dirty_num] = SQ_NONE;
+              dp.to[dp.dirty_num] = gate;
+              dp.dirty_num++;
+          }
 
-      put_piece(gating_piece, gate);
-      remove_from_hand(gating_piece);
+          put_piece(gating_piece, gate);
+          remove_from_hand(gating_piece);
 
-      st->gatesBB[us] ^= gate;
-      k ^= Zobrist::psq[gating_piece][gate];
-      st->materialKey ^= Zobrist::psq[gating_piece][pieceCount[gating_piece]];
-      st->nonPawnMaterial[us] += PieceValue[MG][gating_piece];
+          st->gatesBB[us] ^= gate;
+          k ^= Zobrist::psq[gating_piece][gate];
+          st->materialKey ^= Zobrist::psq[gating_piece][pieceCount[gating_piece]];
+          st->nonPawnMaterial[us] += PieceValue[MG][gating_piece];
+      }
   }
 
   // Remove gates
@@ -2076,6 +2294,47 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       k ^= Zobrist::wall[gating_square(m)];
   }
 
+  if (potions_enabled())
+  {
+      auto togglePotionHashes = [&](Key& key) {
+          for (Color c : {WHITE, BLACK})
+              for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+              {
+                  Variant::PotionType potion = static_cast<Variant::PotionType>(pt);
+                  if (potion_piece(potion) == NO_PIECE_TYPE)
+                      continue;
+
+                  xor_potion_zone(key, c, potion, st->potionZones[c][pt]);
+                  xor_potion_cooldown(key, c, potion, st->potionCooldown[c][pt]);
+              }
+      };
+
+      togglePotionHashes(k);
+
+      for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+      {
+          Variant::PotionType potion = static_cast<Variant::PotionType>(pt);
+          if (potion_piece(potion) == NO_PIECE_TYPE)
+              continue;
+
+          if (gatingPotion == potion)
+          {
+              int cooldown = var->potionCooldown[pt];
+              st->potionCooldown[us][pt] = std::max(cooldown - 1, 0);
+          }
+          else if (st->potionCooldown[us][pt] > 0)
+              --st->potionCooldown[us][pt];
+      }
+
+      st->potionZones[us][Variant::POTION_FREEZE] = gatingPotion == Variant::POTION_FREEZE ? freezeExtra : Bitboard(0);
+      st->potionZones[us][Variant::POTION_JUMP] = Bitboard(0);
+
+      st->potionZones[them][Variant::POTION_FREEZE] = Bitboard(0);
+      st->potionZones[them][Variant::POTION_JUMP] = Bitboard(0);
+
+      togglePotionHashes(k);
+  }
+
   // Update the key with the final value
   st->key = k;
   // Calculate checkers bitboard (if move gives check)
@@ -2172,14 +2431,23 @@ void Position::undo_move(Move m) {
       pc = piece_on(to);
   }
 
-  // Remove gated piece
+  // Remove gated piece or restore potion
   if (is_gating(m))
   {
       Piece gating_piece = make_piece(us, gating_type(m));
-      remove_piece(gating_square(m));
-      board[gating_square(m)] = NO_PIECE;
-      add_to_hand(gating_piece);
-      st->gatesBB[us] |= gating_square(m);
+      Variant::PotionType potion = potion_type_from_piece(var, gating_type(m));
+
+      if (potion != Variant::POTION_TYPE_NB)
+      {
+          add_to_hand(gating_piece);
+      }
+      else
+      {
+          remove_piece(gating_square(m));
+          board[gating_square(m)] = NO_PIECE;
+          add_to_hand(gating_piece);
+          st->gatesBB[us] |= gating_square(m);
+      }
   }
 
   if (type_of(m) == PROMOTION)
@@ -2229,7 +2497,7 @@ void Position::undo_move(Move m) {
               capsq = st->captureSquare;
 
               assert(st->previous->epSquares & to);
-              assert(var->enPassantRegion & to);
+              assert(var->enPassantRegion[sideToMove] & to);
               assert(piece_on(capsq) == NO_PIECE);
           }
 
@@ -2410,14 +2678,39 @@ Value Position::blast_see(Move m) const {
   }
 
   // Sum up blast piece values
+  bool extinctsUs = false;
+  bool extinctsThem = false;
   while (blast)
   {
       Piece bpc = piece_on(pop_lsb(blast));
       if (extinction_piece_types() & type_of(bpc))
-          return color_of(bpc) == us ?  extinction_value()
-                        : capture(m) ? -extinction_value()
-                                     : VALUE_ZERO;
+      {
+          if (color_of(bpc) == us)
+              extinctsUs = true;
+          else
+              extinctsThem = true;
+      }
       result += color_of(bpc) == us ? -CapturePieceValue[MG][bpc] : CapturePieceValue[MG][bpc];
+  }
+
+  // Evaluate extinctions
+  if (!capture(m))
+  {
+      // For quiet moves, the opponent can decide whether to capture or not
+      // so they can pick the better of the two
+      if (extinctsThem && extinctsUs)
+          return VALUE_ZERO;
+      if (extinctsThem)
+          return std::min(-extinction_value(), VALUE_ZERO);
+      if (extinctsUs)
+          return std::min(extinction_value(), VALUE_ZERO);
+  }
+  else
+  {
+      if (extinctsUs)
+          return extinction_value();
+      if (extinctsThem)
+          return -extinction_value();
   }
 
   return capture(m) || must_capture() ? result - 1 : std::min(result, VALUE_ZERO);
@@ -2459,7 +2752,11 @@ bool Position::see_ge(Move m, Value threshold) const {
   if (must_capture() || !checking_permitted() || is_gating(m) || count<CLOBBER_PIECE>() == count<ALL_PIECES>())
       return VALUE_ZERO >= threshold;
 
-  int swap = PieceValue[MG][piece_on(to)] - threshold;
+  Piece victim = piece_on(to);
+  int victimValue = PieceValue[MG][victim];
+  if (victim != NO_PIECE && color_of(victim) == color_of(moved_piece(m)) && self_capture())
+      victimValue = -victimValue;
+  int swap = victimValue - threshold;
   if (swap < 0)
       return false;
 
@@ -3237,7 +3534,7 @@ bool Position::pos_is_ok() const {
   if (   (sideToMove != WHITE && sideToMove != BLACK)
       || (count<KING>(WHITE) && piece_on(square<KING>(WHITE)) != make_piece(WHITE, KING))
       || (count<KING>(BLACK) && piece_on(square<KING>(BLACK)) != make_piece(BLACK, KING))
-      || (ep_squares() & ~var->enPassantRegion))
+      || (ep_squares() & ~(var->enPassantRegion[WHITE] | var->enPassantRegion[BLACK])))
       assert(0 && "pos_is_ok: Default");
 
   if (Fast)

--- a/src/types.h
+++ b/src/types.h
@@ -239,7 +239,7 @@ constexpr int MAX_PLY = 60;
 #endif
 /// endif USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
 #else
-constexpr int MAX_MOVES = 1024;
+constexpr int MAX_MOVES = 4096;
 constexpr int MAX_PLY = 246;
 #endif
 /// endif ALLVARS
@@ -297,6 +297,8 @@ enum CastlingRights {
 enum CheckCount : int {
   CHECKS_0 = 0, CHECKS_NB = 11
 };
+
+constexpr int POTION_COOLDOWN_BITS = 16;
 
 enum MaterialCounting {
   NO_MATERIAL_COUNTING, JANGGI_MATERIAL, UNWEIGHTED_MATERIAL, WHITE_DRAW_ODDS, BLACK_DRAW_ODDS

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -546,7 +546,23 @@ string UCI::move(const Position& pos, Move m) {
   if (is_pass(m) && CurrentProtocol == XBOARD)
       return "@@@@";
 
-  if (is_gating(m) && gating_square(m) == to)
+  bool potionMove = false;
+  std::string potionPrefix;
+
+  if (pos.potions_enabled() && is_gating(m))
+      for (int idx = 0; idx < Variant::POTION_TYPE_NB; ++idx)
+      {
+          PieceType potionPiece = pos.potion_piece(static_cast<Variant::PotionType>(idx));
+          if (!potionMove && potionPiece != NO_PIECE_TYPE
+              && gating_type(m) == potionPiece)
+          {
+              potionMove = true;
+              potionPrefix = std::string(1, pos.piece_to_char()[make_piece(BLACK, gating_type(m))])
+                             + "@" + UCI::square(pos, gating_square(m));
+          }
+      }
+
+  if (is_gating(m) && gating_square(m) == to && !potionMove)
       from = to_sq(m), to = from_sq(m);
   else if (type_of(m) == CASTLING && !pos.is_chess960())
   {
@@ -569,7 +585,7 @@ string UCI::move(const Position& pos, Move m) {
       move += '+';
   else if (type_of(m) == PIECE_DEMOTION)
       move += '-';
-  else if (is_gating(m))
+  else if (is_gating(m) && !potionMove)
   {
       move += pos.piece_to_char()[make_piece(BLACK, gating_type(m))];
       if (gating_square(m) != from)
@@ -579,6 +595,9 @@ string UCI::move(const Position& pos, Move m) {
   // Wall square
   if (pos.walling() && CurrentProtocol != XBOARD)
       move += "," + UCI::square(pos, to) + UCI::square(pos, gating_square(m));
+
+  if (potionMove)
+      move = potionPrefix + "," + move;
 
   return move;
 }

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -80,6 +80,28 @@ namespace {
         v->doubleStepRegion[BLACK] = AllSquares;
         return v;
     }
+    Variant* spell_chess_variant() {
+        Variant* v = chess_variant()->init();
+        v->variantTemplate = "spell-chess";
+        v->potions = true;
+        v->potionPiece[Variant::POTION_FREEZE] = CUSTOM_PIECE_1;
+        v->potionPiece[Variant::POTION_JUMP] = CUSTOM_PIECE_2;
+        v->potionCooldown[Variant::POTION_FREEZE] = 3;
+        v->potionCooldown[Variant::POTION_JUMP] = 3;
+        v->potionDropOnOccupied = true;
+        v->remove_piece(KING);
+        v->add_piece(COMMONER, 'k');
+        v->castlingKingPiece[WHITE] = v->castlingKingPiece[BLACK] = COMMONER;
+        v->pieceToChar[make_piece(WHITE, CUSTOM_PIECE_1)] = 'F';
+        v->pieceToChar[make_piece(BLACK, CUSTOM_PIECE_1)] = 'f';
+        v->pieceToChar[make_piece(WHITE, CUSTOM_PIECE_2)] = 'J';
+        v->pieceToChar[make_piece(BLACK, CUSTOM_PIECE_2)] = 'j';
+        v->extinctionValue = -VALUE_MATE;
+        v->extinctionPieceTypes = piece_set(COMMONER);
+        v->extinctionPieceCount = 0;
+        v->startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[JJFFFFFjjfffff] w KQkq - 0 1";
+        return v;
+    }
     // Berolina Chess
     // https://www.chessvariants.com/dpieces.dir/berlin.html
     Variant* berolina_variant() {
@@ -471,7 +493,8 @@ namespace {
         Variant* v = chess_variant_base()->init();
         v->startFen = "rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1";
         v->doubleStepRegion[WHITE] |= Rank1BB;
-        v->enPassantRegion = Rank3BB | Rank6BB; // exclude en passant on second rank
+        v->enPassantRegion[WHITE] = Rank6BB; // exclude en passant on second rank
+        v->enPassantRegion[BLACK] = Rank3BB; // exclude en passant on second rank
         v->extinctionValue = -VALUE_MATE;
         v->extinctionPieceTypes = piece_set(ALL_PIECES);
         return v;
@@ -595,7 +618,7 @@ namespace {
         v->flagRegion[WHITE] = Rank8BB;
         return v;
     }
-
+	
     // Three-check chess
     // Check the king three times to win
     // https://lichess.org/variant/threeCheck
@@ -613,6 +636,7 @@ namespace {
         v->nnueAlias = "3check";
         return v;
     }
+
     // Crazyhouse
     // Chess with piece drops
     // https://en.wikipedia.org/wiki/Crazyhouse
@@ -624,6 +648,7 @@ namespace {
         v->capturesToHand = true;
         return v;
     }
+	
     // Loop chess
     // Variant of crazyhouse where promoted pawns are not demoted when captured
     // https://en.wikipedia.org/wiki/Crazyhouse#Variations
@@ -633,6 +658,23 @@ namespace {
         v->nnueAlias = "crazyhouse";
         return v;
     }
+	
+	//Capture-Anything
+	// https://www.chess.com/terms/capture-anything-chess
+   Variant* captureanything_variant() {
+	   Variant* v = chess_variant_base()->init();
+	   v->selfCapture = true;
+	     return v;
+    }
+
+    //RecycleChess
+    //	# https://brainking.com/en/GameRules?tp=9
+    Variant* recycle_variant() {
+	 Variant* v = crazyhouse_variant()->init();
+       v->selfCapture = true; 
+  return v;
+    }	   
+
     // Chessgi
     // Variant of loop chess where pawns can be dropped to the first rank
     // https://en.wikipedia.org/wiki/Crazyhouse#Variations
@@ -1073,7 +1115,8 @@ namespace {
         v->nMoveRuleTypes[BLACK] = piece_set(CUSTOM_PIECE_1);
         v->promotionPieceTypes[BLACK] = piece_set(COMMONER) | DRAGON | ARCHBISHOP | CUSTOM_PIECE_2 | CUSTOM_PIECE_3;
         v->promotionLimit[COMMONER] = 2;
-        v->enPassantRegion = 0;
+        v->enPassantRegion[WHITE] = 0;
+        v->enPassantRegion[BLACK] = 0;
         v->extinctionPieceCount = 0;
         v->extinctionPseudoRoyal = true;
         v->dupleCheck = true;
@@ -1831,6 +1874,7 @@ void VariantMap::init() {
     add("nocastle", nocastle_variant());
     add("armageddon", armageddon_variant());
     add("torpedo", torpedo_variant());
+    add("spell-chess", spell_chess_variant());
     add("berolina", berolina_variant());
     add("pawnsideways", pawnsideways_variant());
     add("pawnback", pawnback_variant());
@@ -1870,6 +1914,8 @@ void VariantMap::init() {
     add("isolation7x7", isolation7x7_variant());
     add("snailtrail", snailtrail_variant());
     add("fox-and-hounds", fox_and_hounds_variant());
+	add("captureanything", captureanything_variant());
+	add("recycle", recycle_variant());
 #ifdef ALLVARS
     add("duck", duck_variant());
 #endif

--- a/src/variant.h
+++ b/src/variant.h
@@ -66,12 +66,16 @@ struct Variant {
   bool blastOnCapture = false;
   PieceSet blastImmuneTypes = NO_PIECE_SET;
   PieceSet mutuallyImmuneTypes = NO_PIECE_SET;
+  // Allow capturing pieces of the same color (friendly capture)
+  bool selfCapture = false;
+  // Iron pieces: attempts to capture these piece types are illegal
+  PieceSet ironPieceTypes = NO_PIECE_SET;
   PieceSet petrifyOnCaptureTypes = NO_PIECE_SET;
   bool petrifyBlastPieces = false;
   bool doubleStep = true;
   Bitboard doubleStepRegion[COLOR_NB] = {Rank2BB, Rank7BB};
   Bitboard tripleStepRegion[COLOR_NB] = {};
-  Bitboard enPassantRegion = AllSquares;
+  Bitboard enPassantRegion[COLOR_NB] = {AllSquares, AllSquares};
   PieceSet enPassantTypes[COLOR_NB] = {piece_set(PAWN), piece_set(PAWN)};
   bool castling = true;
   bool castlingDroppedPiece = false;
@@ -118,6 +122,17 @@ struct Variant {
   Rank soldierPromotionRank = RANK_1;
   EnclosingRule flipEnclosedPieces = NO_ENCLOSING;
   bool freeDrops = false;
+
+  enum PotionType : int {
+      POTION_FREEZE,
+      POTION_JUMP,
+      POTION_TYPE_NB
+  };
+
+  bool potions = false;
+  PieceType potionPiece[POTION_TYPE_NB] = {NO_PIECE_TYPE, NO_PIECE_TYPE};
+  int potionCooldown[POTION_TYPE_NB] = {};
+  bool potionDropOnOccupied = false;
 
   // game end
   PieceSet nMoveRuleTypes[COLOR_NB] = {piece_set(PAWN), piece_set(PAWN)};

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -185,6 +185,8 @@
 # blastOnCapture: captures explode all adjacent non-pawn pieces (e.g., atomic chess) [bool] (default: false)
 # blastImmuneTypes: pieces completely immune to explosions (even at ground zero) [PieceSet] (default: none)
 # mutuallyImmuneTypes: pieces that can't capture another piece of same types (e.g., kings (commoners) in atomar) [PieceSet] (default: none)
+# selfCapture: allow capturing one's own pieces [bool] (default: false)
+# ironPieceTypes: pieces that are uncapturable (attempting to capture them is illegal) [PieceSet] (default: none)
 # petrifyOnCaptureTypes: defined pieces are turned into wall squares when capturing [PieceSet] (default: -)
 # petrifyBlastPieces: if petrify and blast combined, should pieces destroyed in the blast be petrified? [bool] (default: false)
 # doubleStep: enable pawn double step [bool] (default: true)
@@ -193,6 +195,8 @@
 # tripleStepRegionWhite: region where pawn triple steps are allowed for white [Bitboard] (default: -)
 # tripleStepRegionBlack: region where pawn triple steps are allowed for black [Bitboard] (default: -)
 # enPassantRegion: define region (target squares) where en passant is allowed after double steps [Bitboard] (default: AllSquares)
+# enPassantRegionWhite: define region (target squares) where en passant is allowed for white [Bitboard] (default: AllSquares)
+# enPassantRegionBlack: define region (target squares) where en passant is allowed for black [Bitboard] (default: AllSquares)
 # enPassantTypes: define pieces able to capture en passant [PieceSet] (default: p)
 # enPassantTypesWhite: define white pieces able to capture en passant [PieceSet] (default: p)
 # enPassantTypesBlack: define black pieces able to capture en passant [PieceSet] (default: p)
@@ -228,6 +232,12 @@
 # dropNoDoubledCount: specifies the count of already existing pieces for dropNoDoubled [int] (default: 1)
 # immobilityIllegal: pieces may not move to squares where they can never move from [bool] (default: false)
 # gating: maintain squares on backrank with extra rights in castling field of FEN [bool] (default: false)
+# potions: enable potion drops and cooldown handling [bool] (default: false)
+# freezePotion: piece type used for freeze potion drops [PieceType] (default: -)
+# jumpPotion: piece type used for jump potion drops [PieceType] (default: -)
+# freezeCooldown: minimum full moves between casting the freeze potion [int] (default: 0)
+# jumpCooldown: minimum full moves between casting the jump potion [int] (default: 0)
+# potionDropOnOccupied: allow potion drops on occupied squares [bool] (default: false)
 # wallingRule: rule on where wall can be placed [WallingRule] (default: none)
 # wallingRegionWhite: mask where wall squares (including duck) can be placed by white [Bitboard] (default: all squares)
 # wallingRegionBlack: mask where wall squares (including duck) can be placed by black [Bitboard] (default: all squares)
@@ -2043,3 +2053,7 @@ flagRegionWhite = *10
 flagRegionBlack = *1
 immobilityIllegal = true
 mandatoryPiecePromotion = true
+
+# Iron pieces demo: pawns are uncapturable; everything else behaves normally.
+[iron-pawns:chess]
+ironPieceTypes = p

--- a/test.py
+++ b/test.py
@@ -2,6 +2,7 @@
 
 import faulthandler
 import unittest
+
 import pyffish as sf
 
 faulthandler.enable()
@@ -120,6 +121,21 @@ commoner = k
 castlingKingPiece = k
 extinctionValue = loss
 extinctionPieceTypes = k
+
+[coregaldrop:coregal]
+pieceDrops = true
+startFen = rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[Qq] w KQkq - 0 1
+
+[cannonatomic:atomic]
+cannon = c
+
+[multipawn:chess]
+soldier = s
+pawnTypes = ps
+
+# Capture-anything: allow self-capture while keeping standard chess rules otherwise
+[capture-anything:chess]
+selfCapture = true
 """
 
 sf.load_variant_config(ini_text)
@@ -236,6 +252,10 @@ variant_positions = {
     "wazirking": {
         "7k/6K1/8/8/8/8/8/8 b - - 0 1": (False, False),  # K vs K
     },
+    "multipawn": {
+        "k7/p7/8/8/8/8/8/K7 w - - 0 1": (True, False),  # K vs KP
+        "k7/s7/8/8/8/8/8/K7 w - - 0 1": (True, False),  # K vs KS
+    },
 }
 
 invalid_variant_positions = {
@@ -284,6 +304,138 @@ invalid_variant_positions = {
 
 
 class TestPyffish(unittest.TestCase):
+
+    @staticmethod
+    def _gating_info(move: str):
+        if "," in move:
+            prefix, suffix = move.split(",", 1)
+            if "@" in prefix:
+                tag, square = prefix.split("@", 1)
+                if len(tag) == 1 and tag.isalpha() and square and square.isalnum():
+                    return suffix, tag.lower(), square
+        if len(move) < 5:
+            return None
+        rank_last = move[-1]
+        if rank_last not in "0123456789":
+            return None
+        if len(move) >= 6 and move[-2] in "0123456789":
+            square = move[-3:]
+            gate_index = -4
+        else:
+            square = move[-2:]
+            gate_index = -3
+        if square[0] not in "abcdefghijklmnopqrstuvwxyz":
+            return None
+        gate_char = move[gate_index]
+        if not gate_char.isalpha():
+            return None
+        return move[:gate_index], gate_char.lower(), square
+
+    @staticmethod
+    def _first_normal_move(moves):
+        for move in moves:
+            if TestPyffish._gating_info(move) is None and "@" not in move:
+                return move
+        raise AssertionError("No normal move available")
+
+    @classmethod
+    def _filter_potion_moves(cls, moves, kind):
+        result = []
+        for move in moves:
+            info = cls._gating_info(move)
+            if info and info[1] == kind:
+                result.append(move)
+        return result
+
+    @classmethod
+    def _has_potion_move(cls, moves, kind):
+        for move in moves:
+            info = cls._gating_info(move)
+            if info and info[1] == kind:
+                return True
+        return False
+
+    @staticmethod
+    def _board_state(fen: str):
+        board = {}
+        board_part = fen.split()[0]
+        rows = board_part.split("/")
+        height = len(rows)
+        width = 0
+        for ch in rows[0]:
+            if ch.isdigit():
+                width += int(ch)
+            elif ch.isalpha():
+                width += 1
+        for rank_index, row in enumerate(rows):
+            file_index = 0
+            for ch in row:
+                if ch.isdigit():
+                    file_index += int(ch)
+                elif ch.isalpha():
+                    square = chr(ord("a") + file_index) + str(height - rank_index)
+                    board[square] = ch
+                    file_index += 1
+        return board, width, height
+
+    @staticmethod
+    def _square_to_coords(square: str):
+        return ord(square[0]) - ord("a"), int(square[1:]) - 1
+
+    @staticmethod
+    def _coords_to_square(file_index: int, rank_index: int):
+        return chr(ord("a") + file_index) + str(rank_index + 1)
+
+    @classmethod
+    def _freeze_zone_has_enemy(cls, board, width, height, square, enemy_color):
+        file_index, rank_index = cls._square_to_coords(square)
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                nx = file_index + dx
+                ny = rank_index + dy
+                if not (0 <= nx < width and 0 <= ny < height):
+                    continue
+                target = cls._coords_to_square(nx, ny)
+                piece = board.get(target)
+                if not piece:
+                    continue
+                if enemy_color == "w" and piece.isupper():
+                    return True
+                if enemy_color == "b" and piece.islower():
+                    return True
+        return False
+
+    @classmethod
+    def _squares_between(cls, origin: str, target: str):
+        ox, oy = cls._square_to_coords(origin)
+        tx, ty = cls._square_to_coords(target)
+        dx = tx - ox
+        dy = ty - oy
+        step_x = (dx > 0) - (dx < 0)
+        step_y = (dy > 0) - (dy < 0)
+        if step_x and step_y and abs(dx) != abs(dy):
+            return []
+        steps = max(abs(dx), abs(dy))
+        squares = []
+        for step in range(1, steps):
+            square = cls._coords_to_square(ox + step_x * step, oy + step_y * step)
+            squares.append(square)
+        return squares
+
+    @classmethod
+    def _jump_uses_gate(cls, move: str, board, width):
+        info = cls._gating_info(move)
+        if not info:
+            return False
+        base = info[0]
+        gate = info[2]
+        if len(base) < 4:
+            return False
+        origin = base[:2]
+        target = base[2:4]
+        if gate not in board:
+            return False
+        return gate in cls._squares_between(origin, target)
     def test_version(self):
         result = sf.version()
         self.assertEqual(len(result), 3)
@@ -346,6 +498,11 @@ class TestPyffish(unittest.TestCase):
         result = sf.legal_moves("seirawan", fen, [])
         self.assertIn("c8g4h", result)
 
+        # Drop pseudo-royals into check
+        result = sf.legal_moves("coregaldrop", sf.start_fen("coregaldrop"), [])
+        self.assertIn("Q@a3", result)
+        self.assertNotIn("Q@a6", result)
+
         # In Cannon Shogi the FGC and FSC can also move one square diagonally and, besides,
         # move or capture two squares diagonally, by leaping an adjacent piece. 
         fen = "lnsg1gsnl/1rc1kuab1/p1+A1p1p1p/3P5/6i2/6P2/P1P1P3P/1B1U1ICR1/LNSGKGSNL[] w - - 1 3"
@@ -397,7 +554,7 @@ class TestPyffish(unittest.TestCase):
         self.assertEqual(['d4c2', 'd4f3', 'd4b5', 'd4e6'], result)
 
 
-    def test_short_castling(self):
+    def test_castling(self):
         legals = ['f5f4', 'a7a6', 'b7b6', 'c7c6', 'd7d6', 'e7e6', 'i7i6', 'j7j6', 'a7a5', 'b7b5', 'c7c5', 'e7e5', 'i7i5', 'j7j5', 'b8a6', 'b8c6', 'h6g4', 'h6i4', 'h6j5', 'h6f7', 'h6g8', 'h6i8', 'd5a2', 'd5b3', 'd5f3', 'd5c4', 'd5e4', 'd5c6', 'd5e6', 'd5f7', 'd5g8', 'j8g8', 'j8h8', 'j8i8', 'e8f7', 'c8b6', 'c8d6', 'g6g2', 'g6g3', 'g6f4', 'g6g4', 'g6h4', 'g6e5', 'g6g5', 'g6i5', 'g6a6', 'g6b6', 'g6c6', 'g6d6', 'g6e6', 'g6f6', 'g6h8', 'f8f7', 'f8g8', 'f8i8']
         moves = ['b2b4', 'f7f5', 'c2c3', 'g8d5', 'a2a4', 'h8g6', 'f2f3', 'i8h6', 'h2h3']
         result = sf.legal_moves("capablanca", CAPA, moves)
@@ -416,6 +573,20 @@ class TestPyffish(unittest.TestCase):
         # d1e1 is a normal king move, so castling has to be d1f1
         result = sf.legal_moves("diana", "rbnk1r/pppbpp/3p2/5P/PPPPPB/RBNK1R w KQkq - 2 3", [])
         self.assertIn("d1f1", result)
+
+        # Atomic960 castling
+        fen = "7k/8/8/8/8/8/2PP4/1RK4q w Q - 0 1"
+        moves = sf.legal_moves("atomic", fen, [], True)
+        # 'c1b1' is the castling move (king to rook square in 960 encoding) and must be illegal
+        self.assertNotIn("c1b1", moves)
+        # A normal king/commoner move like c1b2 should remain legal
+        self.assertIn("c1b2", moves)
+
+        # Atomic960 anti-discovered check with cannon
+        fen = "8/8/8/8/8/6k1/8/c5KR w K - 0 1"
+        moves = sf.legal_moves("cannonatomic", fen, [], True)
+        self.assertNotIn("g1h1", moves)
+        self.assertIn("g1f1", moves)
 
         # Check that in variants where castling rooks are not in the corner
         # the castling rook is nevertheless assigned correctly
@@ -663,6 +834,172 @@ class TestPyffish(unittest.TestCase):
         moves = ["a1a8"]
         result = sf.get_fen("cambodian", fen, moves, False, False, True)
         self.assertEqual(result, "Rnsmksnr/8/1ppppppp/8/8/1PPPPPPP/8/1NSKMSNR b DEd - 0 1")
+
+    def test_capture_anything_knight_self_capture(self):
+        chess_start = sf.start_fen("chess")
+        chess_moves = sf.legal_moves("chess", chess_start, [])
+        self.assertNotIn("g1e2", chess_moves)
+
+        capture_anything_start = sf.start_fen("capture-anything")
+        capture_moves = sf.legal_moves("capture-anything", capture_anything_start, [])
+        self.assertIn("g1e2", capture_moves)
+
+        san = sf.get_san("capture-anything", capture_anything_start, "g1e2")
+        self.assertIn("x", san)
+
+    def test_capture_anything_pawn_self_capture_resets_clock(self):
+        fen = "6k1/8/8/5N2/4P3/8/8/6K1 w - - 17 1"
+        moves = sf.legal_moves("capture-anything", fen, [])
+        self.assertIn("e4f5", moves)
+        self.assertTrue(sf.is_capture("capture-anything", fen, [], "e4f5"))
+
+        new_fen = sf.get_fen("capture-anything", fen, ["e4f5"])
+        self.assertEqual(int(new_fen.split()[4]), 0)
+
+    def test_spell_chess_freeze_blocks_origin(self):
+        start = sf.start_fen("spell-chess")
+        moves = sf.legal_moves("spell-chess", start, [])
+        freeze_moves = self._filter_potion_moves(moves, "f")
+        self.assertTrue(freeze_moves)
+        for move in freeze_moves:
+            self.assertIn(",", move)
+            self.assertEqual(move[0].lower(), "f")
+            self.assertEqual(move[1], "@")
+
+        freeze_on_e2 = [m for m in freeze_moves if self._gating_info(m)[2] == "e2"]
+        self.assertTrue(freeze_on_e2)
+
+        for move in freeze_on_e2:
+            base, _, _ = self._gating_info(move)
+            self.assertNotEqual(base[:2], "e2")
+
+    def test_spell_chess_jump_allows_leap(self):
+        fen = "4k3/8/8/8/8/8/P7/R3K3[JJFFFFFjjfffff] w - - 0 1"
+        moves = sf.legal_moves("spell-chess", fen, [])
+        jump_moves = self._filter_potion_moves(moves, "j")
+        self.assertTrue(jump_moves)
+        for move in jump_moves:
+            self.assertIn(",", move)
+            self.assertEqual(move[0].lower(), "j")
+            self.assertEqual(move[1], "@")
+
+        leap_moves = [m for m in jump_moves if self._gating_info(m)[0] == "a1a3" and self._gating_info(m)[2] == "a2"]
+        self.assertTrue(leap_moves)
+        self.assertNotIn("a1a3", moves)
+
+    def test_spell_chess_has_useless_freeze_targets(self):
+        start = sf.start_fen("spell-chess")
+        moves = sf.legal_moves("spell-chess", start, [])
+        freeze_moves = self._filter_potion_moves(moves, "f")
+        self.assertTrue(freeze_moves)
+        board, width, height = self._board_state(start)
+        enemy = "b" if start.split()[1] == "w" else "w"
+        useless = [
+            move
+            for move in freeze_moves
+            if not self._freeze_zone_has_enemy(board, width, height, self._gating_info(move)[2], enemy)
+        ]
+        self.assertTrue(useless)
+
+    def test_spell_chess_has_useless_jump_targets(self):
+        start = sf.start_fen("spell-chess")
+        history = [
+            "e2e4",
+            "e7e5",
+            "f1c4",
+            "f8c5",
+            "f@d7,c4f7",
+            "f@e6,c5f2",
+            "e1f2",
+        ]
+        moves = sf.legal_moves("spell-chess", start, history)
+        jump_moves = self._filter_potion_moves(moves, "j")
+        self.assertTrue(jump_moves)
+        fen_after = sf.get_fen("spell-chess", start, history)
+        board, width, height = self._board_state(fen_after)
+        useless = [m for m in jump_moves if not self._jump_uses_gate(m, board, width)]
+        self.assertIn("j@a1,e8f7", useless)
+    def test_spell_chess_freeze_cooldown(self):
+        start = "4k3/8/8/8/8/8/8/4K1N1[JJFFFFFjjfffff] w - - 0 1"
+        history = []
+
+        moves = sf.legal_moves("spell-chess", start, history)
+        freeze_moves = self._filter_potion_moves(moves, "f")
+        self.assertTrue(freeze_moves)
+        history.append(freeze_moves[0])
+
+        cooldown_full_moves = 3
+        for _ in range(max(cooldown_full_moves - 1, 0)):
+            moves = sf.legal_moves("spell-chess", start, history)
+            history.append(self._first_normal_move(moves))
+
+            moves = sf.legal_moves("spell-chess", start, history)
+            self.assertFalse(self._has_potion_move(moves, "f"))
+            history.append(self._first_normal_move(moves))
+
+        moves = sf.legal_moves("spell-chess", start, history)
+        history.append(self._first_normal_move(moves))
+
+        moves = sf.legal_moves("spell-chess", start, history)
+        self.assertTrue(self._has_potion_move(moves, "f"))
+
+    def test_spell_chess_freeze_cooldown_regression(self):
+        history = [
+            "d2d4",
+            "e7e6",
+            "c2c3",
+            "c7c6",
+            "e2e4",
+            "g8f6",
+            "f1d3",
+            "f8e7",
+            "f@e7,e4e5",
+            "b8a6",
+            "e5f6",
+            "e7f6",
+            "j@b2,c1a3",
+            "d8a5",
+            "e1f1",
+            "d7d6",
+            "d1e2",
+            "f6e7",
+            "a3d6",
+            "a5g5",
+            "g1f3",
+            "g5f6",
+            "d6e5",
+            "f@f1,f6f3",
+            "f@f4,b1d2",
+            "j@h7,h8h2",
+            "e2f3",
+            "h2h1",
+            "j@f1,a1h1",
+            "c8d7",
+            "h1h7",
+            "e8d8",
+            "f3f7",
+            "d7e8",
+            "f@d8,f7e7",
+            "f@f6,a8b8",
+            "h7g7",
+            "d8c8",
+            "e7e6",
+            "e8d7",
+            "e6d7",
+        ]
+
+        moves = sf.legal_moves("spell-chess", "startpos", history)
+        self.assertIn("f@f6,c8d7", moves)
+    def test_spell_chess_jump_capture_wins_immediately(self):
+        fen = "5rk1/1p2ppb1/2p1q1p1/3p2Np/3P2n1/3BP3/PPP2PPP/R1B1K2R[JFFFFjffff] b KQ - 5 12"
+        result = sf.game_result("spell-chess", fen, ["j@e3,e6e1"])
+        self.assertEqual(result, -sf.VALUE_MATE)
+
+    def test_spell_chess_freeze_check_does_not_win(self):
+        fen = "rnbqk1nr/pppp1ppp/8/1N2p3/1b6/8/PPPPPPPP/R1BQKBNR[JJFFFFFjjfffff] w KQkq - 2 3"
+        result = sf.game_result("spell-chess", fen, ["f@d7,b5c7"])
+        self.assertNotEqual(result, sf.VALUE_MATE)
+        self.assertNotEqual(result, -sf.VALUE_MATE)
 
     def test_get_san(self):
         fen = "4k3/8/3R4/8/1R3R2/8/3R4/4K3 w - - 0 1"

--- a/tests/regression.sh
+++ b/tests/regression.sh
@@ -1,12 +1,40 @@
 #!/bin/bash
 # regression test variant bench numbers
-# arguments: ./old_engine ./new_engine variant1 variant2 variant3 ...
+# arguments: ./old_engine ./new_engine "bench_args" [variant1 variant2 variant3 ...]
+# examples:
+#   Pure bench: ./regression.sh ./old_engine ./new_engine "" chess xiangqi shogi
+#   Perft bench: ./regression.sh ./old_engine ./new_engine "16 1 5 default perft" chess xiangqi shogi
+#   Auto-detect common variants: ./regression.sh ./old_engine ./new_engine ""
 
 echo "variant $1 $2"
-for var in "${@:3}"
+bench_args="$3"
+
+# If no variants provided, extract them from UCI output
+if [ $# -eq 3 ]; then
+    echo "No variants specified, extracting from UCI output..."
+    
+    # Extract variants from first engine
+    variants1=$(echo "uci" | $1 2>/dev/null | grep "option name UCI_Variant" | grep -o 'var [^[:space:]]*' | sed 's/var //' | sort)
+    
+    # Extract variants from second engine
+    variants2=$(echo "uci" | $2 2>/dev/null | grep "option name UCI_Variant" | grep -o 'var [^[:space:]]*' | sed 's/var //' | sort)
+    
+    # Find intersection of variants (common to both engines)
+    variants=$(comm -12 <(echo "$variants1") <(echo "$variants2"))
+    
+    echo "Common variants found: $(echo $variants | wc -w)"
+
+    # Convert to array for processing
+    variant_array=($variants)
+else
+    # Use provided variants
+    variant_array=("${@:4}")
+fi
+
+for var in "${variant_array[@]}"
 do
-    ref=`$1 bench $var 2>&1 | grep "Nodes searched  : " | awk '{print $4}'`
-    signature=`$2 bench $var 2>&1 | grep "Nodes searched  : " | awk '{print $4}'`
+    ref=`$1 bench $var $bench_args 2>&1 | grep "Nodes searched  : " | awk '{print $4}'`
+    signature=`$2 bench $var $bench_args 2>&1 | grep "Nodes searched  : " | awk '{print $4}'`
     if [ -z "$ref" ]; then
         echo "${var} none ${signature} <-- no reference"
     elif [ -z "$signature" ]; then


### PR DESCRIPTION
## Summary
- merge Belzedar94's spell chess feature branch to add potion-enabled spell chess along with capture-anything and recycle variants
- extend engine core to support potions, friendly captures, and related move generation and UCI handling updates
- update tests, regression tooling, and documentation to cover the new mechanics
- incorporate upstream refinements that skip useless potion gating moves and add Spell Chess regression coverage

## Testing
- python3 test.py *(fails: ModuleNotFoundError: No module named 'pyffish')*

------
https://chatgpt.com/codex/tasks/task_e_68da83e992a883228a91dd1ca44f01e9