### PR TITLE
Add NNUE wall-square support and enable GitHub Actions on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/merge-nnue-to-bookgen.yml
+++ b/.github/workflows/merge-nnue-to-bookgen.yml
@@ -8,6 +8,10 @@ on:
   workflow_dispatch:
     # Allow manual trigger
 
+  pull_request:
+    branches:
+      - master
+
 jobs:
   merge_branches:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   windows:

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -23,6 +23,10 @@ on:
           - '1 year ago'
         default: '1 week ago'
 
+  pull_request:
+    branches:
+      - master
+
 jobs:
   sync_latest_from_upstream:
     runs-on: ubuntu-latest

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -119,7 +119,7 @@ namespace Stockfish::Eval::NNUE {
 
     std::uint32_t hashValue;
     if (!read_header(stream, &hashValue, &netDescription)) return false;
-    if (hashValue != HashValue) return false;
+    if (hashValue != hash_value()) return false;
     if (!Detail::read_parameters(stream, *featureTransformer)) return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
       if (!Detail::read_parameters(stream, *(network[i]))) return false;
@@ -129,7 +129,7 @@ namespace Stockfish::Eval::NNUE {
   // Write network parameters
   bool write_parameters(std::ostream& stream) {
 
-    if (!write_header(stream, HashValue, netDescription)) return false;
+    if (!write_header(stream, hash_value(), netDescription)) return false;
     if (!Detail::write_parameters(stream, *featureTransformer)) return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
       if (!Detail::write_parameters(stream, *(network[i]))) return false;

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -28,8 +28,9 @@
 namespace Stockfish::Eval::NNUE {
 
   // Hash value of evaluation function structure
-  constexpr std::uint32_t HashValue =
-      FeatureTransformer::get_hash_value() ^ Network::get_hash_value();
+  inline std::uint32_t hash_value() {
+    return FeatureTransformer::get_hash_value() ^ Network::get_hash_value();
+  }
 
   // Deleter for automating release of memory area
   template <typename T>

--- a/src/nnue/features/half_ka_v2_variants.cpp
+++ b/src/nnue/features/half_ka_v2_variants.cpp
@@ -46,6 +46,10 @@ namespace Stockfish::Eval::NNUE::Features {
     return IndexType(handCount + pos.nnue_piece_hand_index(perspective, pc) + pos.nnue_king_square_index(ksq));
   }
 
+  inline IndexType HalfKAv2Variants::make_wall_index(Color perspective, Square s, Square ksq, const Position& pos) {
+    return IndexType(orient(perspective, s, pos) + pos.nnue_wall_index_base() + pos.nnue_king_square_index(ksq));
+  }
+
   // Get a list of indices for active features
   void HalfKAv2Variants::append_active_indices(
     const Position& pos,
@@ -58,6 +62,16 @@ namespace Stockfish::Eval::NNUE::Features {
     {
       Square s = pop_lsb(bb);
       active.push_back(make_index(perspective, s, pos.piece_on(s), oriented_ksq, pos));
+    }
+
+    if (pos.nnue_wall_index_base() >= 0)
+    {
+      Bitboard walls = pos.state()->wallSquares;
+      while (walls)
+      {
+        Square s = pop_lsb(walls);
+        active.push_back(make_wall_index(perspective, s, oriented_ksq, pos));
+      }
     }
 
     // Indices for pieces in hand
@@ -95,14 +109,31 @@ namespace Stockfish::Eval::NNUE::Features {
       else if (dp.handPiece[i] != NO_PIECE)
         added.push_back(make_index(perspective, dp.handCount[i] - 1, dp.handPiece[i], oriented_ksq, pos));
     }
+
+    if (pos.nnue_wall_index_base() >= 0)
+    {
+      Bitboard prevWalls = st->previous ? st->previous->wallSquares : Bitboard(0);
+      Bitboard removedWalls = prevWalls & ~st->wallSquares;
+      Bitboard addedWalls = st->wallSquares & ~prevWalls;
+      while (removedWalls)
+        removed.push_back(make_wall_index(perspective, pop_lsb(removedWalls), oriented_ksq, pos));
+      while (addedWalls)
+        added.push_back(make_wall_index(perspective, pop_lsb(addedWalls), oriented_ksq, pos));
+    }
   }
 
   int HalfKAv2Variants::update_cost(StateInfo* st) {
-    return st->dirtyPiece.dirty_num;
+    if (!currentNnueVariant || currentNnueVariant->nnueWallIndexBase < 0)
+      return st->dirtyPiece.dirty_num;
+    Bitboard diff = st->previous ? st->wallSquares ^ st->previous->wallSquares : st->wallSquares;
+    return st->dirtyPiece.dirty_num + popcount(diff);
   }
 
   int HalfKAv2Variants::refresh_cost(const Position& pos) {
-    return pos.count<ALL_PIECES>();
+    int cost = pos.count<ALL_PIECES>();
+    if (pos.nnue_wall_index_base() >= 0)
+      cost += popcount(pos.state()->wallSquares);
+    return cost;
   }
 
   bool HalfKAv2Variants::requires_refresh(StateInfo* st, Color perspective, const Position& pos) {

--- a/src/nnue/features/half_ka_v2_variants.h
+++ b/src/nnue/features/half_ka_v2_variants.h
@@ -47,22 +47,32 @@ namespace Stockfish::Eval::NNUE::Features {
     // Index of a feature for a given king position and another piece in hand
     static IndexType make_index(Color perspective, int handCount, Piece pc, Square ksq, const Position& pos);
 
+    // Index of a feature for a given king position and a wall square
+    static IndexType make_wall_index(Color perspective, Square s, Square ksq, const Position& pos);
+
    public:
     // Feature name
     static constexpr const char* Name = "HalfKAv2(Friend)";
 
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t HashValue = 0x5f234cb8u;
+    static constexpr std::uint32_t HashValueNoWalls = 0x5f234cb8u;
+    static constexpr std::uint32_t HashValueWithWalls = 0x9e5a2c13u;
+
+    static std::uint32_t get_hash_value() {
+      return currentNnueVariant && currentNnueVariant->nnueWallIndexBase >= 0
+             ? HashValueWithWalls
+             : HashValueNoWalls;
+    }
 
     // Number of feature dimensions
-    static constexpr IndexType Dimensions = static_cast<IndexType>(SQUARE_NB) * static_cast<IndexType>(SQUARE_NB) * 19;
+    static constexpr IndexType Dimensions = static_cast<IndexType>(SQUARE_NB) * static_cast<IndexType>(SQUARE_NB) * 20;
 
     static IndexType get_dimensions() {
       return currentNnueVariant->nnueDimensions;
     }
 
     // Maximum number of simultaneously active features.
-    static constexpr IndexType MaxActiveDimensions = 128;
+    static constexpr IndexType MaxActiveDimensions = 2 * static_cast<IndexType>(SQUARE_NB);
 
     // Get a list of indices for active features
     static void append_active_indices(

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -204,8 +204,8 @@ namespace Stockfish::Eval::NNUE {
         OutputDimensions * sizeof(OutputType);
 
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t get_hash_value() {
-      return FeatureSet::HashValue ^ OutputDimensions;
+    static std::uint32_t get_hash_value() {
+      return FeatureSet::get_hash_value() ^ OutputDimensions;
     }
 
     // Read network parameters

--- a/src/position.h
+++ b/src/position.h
@@ -156,11 +156,12 @@ public:
   PieceType king_type() const;
   PieceType nnue_king() const;
   Square nnue_king_square(Color c) const;
-  bool nnue_use_pockets() const;
-  bool nnue_applicable() const;
-  int nnue_piece_square_index(Color perspective, Piece pc) const;
-  int nnue_piece_hand_index(Color perspective, Piece pc) const;
-  int nnue_king_square_index(Square ksq) const;
+    bool nnue_use_pockets() const;
+    bool nnue_applicable() const;
+    int nnue_piece_square_index(Color perspective, Piece pc) const;
+    int nnue_piece_hand_index(Color perspective, Piece pc) const;
+    int nnue_king_square_index(Square ksq) const;
+    int nnue_wall_index_base() const;
   bool free_drops() const;
   bool fast_attacks() const;
   bool fast_attacks2() const;
@@ -609,15 +610,20 @@ inline int Position::nnue_piece_hand_index(Color perspective, Piece pc) const {
   return var->pieceHandIndex[perspective][pc];
 }
 
-inline int Position::nnue_king_square_index(Square ksq) const {
-  assert(var != nullptr);
-  return var->kingSquareIndex[ksq];
-}
+  inline int Position::nnue_king_square_index(Square ksq) const {
+    assert(var != nullptr);
+    return var->kingSquareIndex[ksq];
+  }
 
-inline bool Position::checking_permitted() const {
-  assert(var != nullptr);
-  return var->checking;
-}
+  inline int Position::nnue_wall_index_base() const {
+    assert(var != nullptr);
+    return var->nnueWallIndexBase;
+  }
+
+  inline bool Position::checking_permitted() const {
+    assert(var != nullptr);
+    return var->checking;
+  }
 
 inline bool Position::free_drops() const {
   assert(var != nullptr);

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -2006,11 +2006,17 @@ Variant* Variant::conclude() {
     }
     // We can not use popcount here yet, as the lookup tables are initialized after the variants
     int nnueSquares = (maxRank + 1) * (maxFile + 1);
-    nnueUsePockets = (pieceDrops && (capturesToHand || (!mustDrop && std::bitset<64>(pieceTypes).count() != 1))) || seirawanGating;
-    int nnuePockets = nnueUsePockets ? 2 * int(maxFile + 1) : 0;
-    int nnueNonDropPieceIndices = (2 * std::bitset<64>(pieceTypes).count() - (nnueKing != NO_PIECE_TYPE)) * nnueSquares;
-    int nnuePieceIndices = nnueNonDropPieceIndices + 2 * (std::bitset<64>(pieceTypes).count() - (nnueKing != NO_PIECE_TYPE)) * nnuePockets;
-    int i = 0;
+      nnueUsePockets = (pieceDrops && (capturesToHand || (!mustDrop && std::bitset<64>(pieceTypes).count() != 1))) || seirawanGating;
+      int nnuePockets = nnueUsePockets ? 2 * int(maxFile + 1) : 0;
+      int nnueNonDropPieceIndices = (2 * std::bitset<64>(pieceTypes).count() - (nnueKing != NO_PIECE_TYPE)) * nnueSquares;
+      int nnuePieceIndices = nnueNonDropPieceIndices + 2 * (std::bitset<64>(pieceTypes).count() - (nnueKing != NO_PIECE_TYPE)) * nnuePockets;
+      bool nnueHasWalls = wallingRule != NO_WALLING
+                       || petrifyOnCaptureTypes != NO_PIECE_SET
+                       || startFen.find('*') != std::string::npos;
+      nnueWallIndexBase = nnueHasWalls ? nnuePieceIndices : -1;
+      if (nnueHasWalls)
+          nnuePieceIndices += nnueSquares;
+      int i = 0;
     for (PieceSet ps = pieceTypes; ps;)
     {
         // Make sure that the nnueKing type gets the last index, since the NNUE architecture relies on that

--- a/src/variant.h
+++ b/src/variant.h
@@ -166,10 +166,11 @@ struct Variant {
   // Derived properties
   bool fastAttacks = true;
   bool fastAttacks2 = true;
-  std::string nnueAlias = "";
-  PieceType nnueKing = KING;
-  int nnueDimensions;
-  bool nnueUsePockets;
+    std::string nnueAlias = "";
+    PieceType nnueKing = KING;
+    int nnueDimensions = 0;
+    int nnueWallIndexBase = -1;
+    bool nnueUsePockets = false;
   int pieceSquareIndex[COLOR_NB][PIECE_NB];
   int pieceHandIndex[COLOR_NB][PIECE_NB];
   int kingSquareIndex[SQUARE_NB];


### PR DESCRIPTION
### Motivation
- Add NNUE evaluation support for variant-specific wall squares so features include wall positions and update costs correctly.
- Ensure CI and repository sync workflows run for pull requests by enabling `pull_request` triggers in workflows.

### Description
- Add NNUE wall indexing and tracking by introducing `nnueWallIndexBase` in `Variant`, the accessor `Position::nnue_wall_index_base()`, and wall-feature index construction via `HalfKAv2Variants::make_wall_index`; walls are now included in `append_active_indices`, `append_changed_indices`, `update_cost`, and `refresh_cost` (files changed include `src/variant.h`, `src/variant.cpp`, `src/position.h`, and `src/nnue/features/half_ka_v2_variants.*`).
- Adjust NNUE hash/serialization API by replacing inline `HashValue` constants with `hash_value()` / `get_hash_value()` helpers and updating serialization calls to use `hash_value()`, and make `FeatureTransformer::get_hash_value()` call `FeatureSet::get_hash_value()` (changes in `src/nnue/evaluate_nnue.*` and `src/nnue/nnue_feature_transformer.h`).
- Update feature sizing for `HalfKAv2Variants` by increasing `Dimensions` and `MaxActiveDimensions` to account for wall features and add a variant-aware `get_hash_value()` for the feature set (changes in `src/nnue/features/half_ka_v2_variants.*`).
- Enable workflows to run on pull requests by adding `pull_request` triggers to `CI`, `merge-nnue-to-bookgen`, and `upstream-sync` workflows and applying a small cleanup to `release.yml` (files changed under `.github/workflows/`).

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696765d1b2308322b1b932d47af44cb1)